### PR TITLE
Allow hyphenated db names in role definition

### DIFF
--- a/lib/puppet/type/mongos_user.rb
+++ b/lib/puppet/type/mongos_user.rb
@@ -41,7 +41,7 @@ Puppet::Type.newtype(:mongos_user) do
   newproperty(:roles, :array_matching => :all) do
     desc "The user's roles."
     defaultto ['dbAdmin']
-    newvalue(/^\w+(|@\w+)$/)
+    newvalue(/^\w+(|@[\w-]+)$/)
 
     # Pretty output for arrays.
     def should_to_s(value)


### PR DESCRIPTION
Currently we are using a regex to allow hyphens in DB names. Hyphens in DB names are fine with mongo, and we have existing DBs with hyphenated names.
However, in the roles array we are using a different regex for the DB part of the role which only allows \w. This should be changed to match the DB criteria.